### PR TITLE
feat: add ability to pass gh registry token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   actions_comment:
     description: "Whether or not to comment on pull requests."
     default: false
+  github_package_registry_token:
+    description: "Github package registry token to install dependencies outside of npm"
+    default: ""
 runs:
   using: "docker"
   image: "./Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,10 @@ function installAwsSam(){
 }
 
 function runSam(){
+	if [ "${INPUT_GITHUB_PACKAGE_REGISTRY_TOKEN}" == "" ]; then
+		echo "//npm.pkg.github.com/:_authToken=${INPUT_GITHUB_PACKAGE_REGISTRY_TOKEN}" > ~/.npmrc
+	fi
+
 	echo "Run sam ${INPUT_SAM_COMMAND}"
 	output=$(sam ${INPUT_SAM_COMMAND} 2>&1)
 	exitCode=${?}


### PR DESCRIPTION
## Description

Adds the ability to pass a github package registry token to install packages that aren't served up by npm.

Adds Feature or Fixes: # (issue)

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally
