### PR TITLE
docs: correct AWS_DEFAULT_REGION key in README deploy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Github action for using the [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli
   env:
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    AWS_DEFAULT_REGION: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
 ```


### PR DESCRIPTION
## Description

This change corrects a README mistake in the `AWS_DEFAULT_REGION` key used to pull from GitHub secrets

Adds Feature or Fixes: # (issue)

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The test workflow is passing locally

## Screenshots/GIFs
N/A
