### PR TITLE
revert: python 3.7 to python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.7-nodejs12-alpine
+FROM nikolaik/python-nodejs:python3.8-nodejs12-alpine
 
 ENV SAM_CLI_TELEMETRY 0
 


### PR DESCRIPTION
## Description

Adds Feature or Fixes: #10 

Reverting to return to using the image with python 3.8

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally
