### PR TITLE
Support for Go and Custom builds 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,9 @@
 FROM nikolaik/python-nodejs:python3.7-nodejs12-alpine
 
 ENV SAM_CLI_TELEMETRY 0
-ENV GLIBC_VERSION=2.31-r0
 
-RUN apk update && apk upgrade && \
-    mkdir -p /etc/BUILDS/ && \
-    printf "Build of nimmis/alpine-glibc:3.12, date: %s\n"  `date -u +"%Y-%m-%dT%H:%M:%SZ"` > /etc/BUILDS/alpine-glibc && \
-    apk add jq curl bash gcc git make musl-dev libc6-compat && \
-    curl -Ls -o /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    curl -Ls -o glibc-${GLIBC_VERSION}.apk \
-      "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
-    curl -Ls -o glibc-bin-${GLIBC_VERSION}.apk \
-      "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \
-    apk add  glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk && \
-    curl -Ls -o /tmp/libz.tar.xz "https://www.archlinux.org/packages/core/x86_64/zlib/download" && \
-    mkdir -p /tmp/libz && \
-    tar -xJf /tmp/libz.tar.xz -C /tmp/libz && \
-    cp /tmp/libz/usr/lib/libz.so.1.2.11 /usr/glibc-compat/lib && \
-    /usr/glibc-compat/sbin/ldconfig && \
-    rm -rf /tmp/libz /tmp/libz.tar.xz && \
-    apk del curl && \
-    rm -fr glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk /var/cache/apk/* 
+RUN apk --update --no-cache add jq curl bash gcc git make musl-dev libc6-compat tar
+RUN curl https://dl.google.com/go/go1.14.6.src.tar.gz | tar -xzf - -C /usr/local 
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,26 @@
 FROM nikolaik/python-nodejs:python3.7-nodejs12-alpine
 
 ENV SAM_CLI_TELEMETRY 0
+ENV GLIBC_VERSION=2.31-r0
 
-RUN apk --update --no-cache add jq curl bash gcc git make musl-dev go libc6-compat
+RUN apk update && apk upgrade && \
+    mkdir -p /etc/BUILDS/ && \
+    printf "Build of nimmis/alpine-glibc:3.12, date: %s\n"  `date -u +"%Y-%m-%dT%H:%M:%SZ"` > /etc/BUILDS/alpine-glibc && \
+    apk add jq curl bash gcc git make musl-dev libc6-compat && \
+    curl -Ls -o /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    curl -Ls -o glibc-${GLIBC_VERSION}.apk \
+      "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
+    curl -Ls -o glibc-bin-${GLIBC_VERSION}.apk \
+      "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \
+    apk add  glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk && \
+    curl -Ls -o /tmp/libz.tar.xz "https://www.archlinux.org/packages/core/x86_64/zlib/download" && \
+    mkdir -p /tmp/libz && \
+    tar -xJf /tmp/libz.tar.xz -C /tmp/libz && \
+    cp /tmp/libz/usr/lib/libz.so.1.2.11 /usr/glibc-compat/lib && \
+    /usr/glibc-compat/sbin/ldconfig && \
+    rm -rf /tmp/libz /tmp/libz.tar.xz && \
+    apk del curl && \
+    rm -fr glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk /var/cache/apk/* 
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV SAM_CLI_TELEMETRY 0
 
 RUN apk --update --no-cache add jq curl bash gcc git make musl-dev libc6-compat tar
 RUN curl https://dl.google.com/go/go1.14.6.src.tar.gz | tar -xzf - -C /usr/local 
-
+ENV GOROOT /usr/local/go
+ENV PATH ${PATH}:${GOROOT}/bin
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nikolaik/python-nodejs:python3.7-nodejs12-alpine
 
 ENV SAM_CLI_TELEMETRY 0
 
-RUN apk --update --no-cache add jq curl bash gcc git make musl-dev go
+RUN apk --update --no-cache add jq curl bash gcc git make musl-dev go libc6-compat
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM nikolaik/python-nodejs:python3.7-nodejs12-alpine
 ENV SAM_CLI_TELEMETRY 0
 
 RUN apk --update --no-cache add jq curl bash gcc git make musl-dev libc6-compat tar
-RUN curl https://dl.google.com/go/go1.14.6.src.tar.gz | tar -xzf - -C /usr/local 
+RUN curl https://dl.google.com/go/go1.14.6.src.tar.gz | tar -xvzf - -C /usr/local 
 ENV GOROOT /usr/local/go
 ENV PATH ${PATH}:${GOROOT}/bin
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nikolaik/python-nodejs:python3.7-nodejs12-alpine
 
 ENV SAM_CLI_TELEMETRY 0
 
-RUN apk --update --no-cache add jq curl bash gcc musl-dev
+RUN apk --update --no-cache add jq curl bash gcc git make musl-dev go
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM nikolaik/python-nodejs:python3.7-nodejs12-alpine
 
 ENV SAM_CLI_TELEMETRY 0
 
-RUN apk --update --no-cache add jq curl bash gcc git make musl-dev libc6-compat tar
-RUN curl https://dl.google.com/go/go1.14.6.src.tar.gz | tar -xvzf - -C /usr/local 
+RUN apk --update --no-cache add jq curl bash gcc git make musl-dev libc6-compat tar && \
+  curl https://dl.google.com/go/go1.14.6.linux-amd64.tar.gz | tar -xvzf - -C /usr/local 
 ENV GOROOT /usr/local/go
 ENV PATH ${PATH}:${GOROOT}/bin
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # @TractorZoom/sam-cli-action
 
-_Tractor Zoom primarily works in Node.js so this action has NOT been tested extensively with Python. As always, new features, bug fixes, and other contributions are always welcome! Please submit a PR or an Issue._
+_Tractor Zoom primarily works in Node.js so this action has NOT been tested extensively with Python & Go. As always, new features, bug fixes, and other contributions are always welcome! Please submit a PR or an Issue._
 
-Github action for using the [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli) to build and deploy serverless applications written in node 12.x and python 3.8.
+Github action for using the [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli) to build and deploy serverless applications written in node 12.x, python 3.8 and go 1.14.6 as well as with custom build makefiles.
 
 ### Getting Started:
 


### PR DESCRIPTION
## Description

This adds support for
* Go 1.14.6
* Custom builds (ie makefile support) - (Which you need to use with Go where it isn't just a binary due to a bad go implementation)

Please note; you can't simply install the Go module from apk because it's compiled with musl not libc, so you have to download it.

Adds Feature or Fixes: # (issue)

- [x] I have performed a self-review of my own code - it works in my env
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally

## Screenshots/GIFs

![image](https://user-images.githubusercontent.com/20219956/88146434-3278b980-cc3f-11ea-803e-362fae2f2e98.png)
