### PR TITLE
Fail command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   sam_command:
     description: "AWS SAM subcommand to execute."
     required: true
+  fail_command:
+    description: "Command to run on sam failing (to get logs etc.)"
+    required: false
   actions_comment:
     description: "Whether or not to comment on pull requests."
     default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,9 +63,9 @@ ${output}
 	fi
 
 	if [ "${exitCode}" == "1" ]; then
-		if [ "${fail_command}" != "" ]; then 
-			echo "Executing fail command; ${fail_command@Q}";
-			eval "${fail_command}";
+		if [ "${INPUT_FAIL_COMMAND}" != "" ]; then 
+			echo "Executing fail command; ${INPUT_FAIL_COMMAND@Q}";
+			eval "${INPUT_FAIL_COMMAND}";
 		fi
 		exit 1
 	fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,10 @@ ${output}
 	fi
 
 	if [ "${exitCode}" == "1" ]; then
+		if [ "${fail_command}" != "" ]; then 
+			echo "Executing fail command; ${fail_command@Q}";
+			eval "${fail_command}";
+		fi
 		exit 1
 	fi
 }


### PR DESCRIPTION
## Description

Added a fail command to help developers interrogate the container when there is a failure. Due to limitations in accessibility in github actions.

Adds Feature or Fixes: # (issue)

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally

## Screenshots/GIFs/usage example

```
            - name: sam build
              uses: aubelsb2/sam-cli-action@master
              with:
                  sam_command: "build --debug"
                  fail_command: "more /github/home/.npm/_logs/*"
```